### PR TITLE
add featured media

### DIFF
--- a/tunein/__init__.py
+++ b/tunein/__init__.py
@@ -68,10 +68,10 @@ class TuneIn:
     @staticmethod
     def search(query):
         res = requests.post(TuneIn.search_url, data={"query": query})
-        yield from TuneIn._get_stations(res)
+        yield from TuneIn._get_stations(res, query)
 
     @staticmethod
-    def _get_stations(res: requests.Response):
+    def _get_stations(res: requests.Response, query: str = ""):
         res = xml2dict(res.text)
         if not res.get("opml"):
             return
@@ -93,7 +93,8 @@ class TuneIn:
                          "title": entry.get("current_track") or entry.get("text"),
                          "artist": entry.get("text"),
                          "description": entry.get("subtext"),
-                         "image": entry.get("image")
+                         "image": entry.get("image"),
+                         "query": query
                          })
 
             except:


### PR DESCRIPTION
This adds a playlist aggregator, that yields the local radiostations used as featured media in ovos ocp

minor additions to TuneInStation class to also represent the artist (if available)
also filter "unavailable" stations that are broken but listed on the service 