### PR TITLE
fix voice requests

### DIFF
--- a/tunein/__init__.py
+++ b/tunein/__init__.py
@@ -78,13 +78,13 @@ class TuneIn:
         # stations might be nested based on Playlist/Search
         outline = res['opml']['body']["outline"]
 
-        if isinstance(outline, list):
-            outline = outline[0]
-        assert isinstance(outline, dict)
-        if outline.get("outline"):
-            stations = outline["outline"]
+        if not isinstance(outline, list):
+            return
+        if outline[0].get("outline"):
+            stations = outline[0]["outline"]
         else:
             stations = outline
+
         for entry in stations:
             try:
                 if not entry.get("key") == "unavailable" \


### PR DESCRIPTION
https://github.com/OpenJarbas/tunein/blob/6ef49c6d929a7831a2317a61a740445fc101ef3a/tunein/__init__.py#L79-L89

Problem: `outline` is always a list (voice search/ featured media)

search comes in: `[{station},{station},...]`
featured comes in: `[{"outline": [{station}, {station}] }, {uninteresting}]`

and thus iterating over a single station (rather than a list of stations) in case of a search

This was missed last time as the review was pending.