### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 # TuneIn
 
-Unofficial python api for TuneIn, with first-class
-[mediavocab](https://github.com/JarbasAl/mediavocab) integration.
+TuneIn is an unofficial Python client for the TuneIn radio API. It integrates
+with [mediavocab](https://github.com/JarbasAl/mediavocab) so callers get
+typed, canonical media objects instead of raw API responses.
+
+## Install
+
+```bash
+pip install tunein
+```
 
 ## Usage
 
 ### From the command line
 
 `tunein` ships a basic CLI for searching. Output is available in both
-`json` and table formats; the default is the table layout.
+`json` and table formats. The default is the table layout.
 
 ```bash
 tunein search "Radio paradise"
 tunein search "Radio paradise" --format json
 ```
 
-CLI help is available with `tunein --help`.
+Run `tunein --help` to see the full command list.
 
 ### From Python
 
@@ -28,41 +35,41 @@ for station in TuneIn.search("BBC Radio 4"):
 
 ### mediavocab integration
 
-`TuneInStation.to_release()` emits a canonical `mediavocab.Release` so
-downstream consumers (OCP, recommendation engines, catalogue importers)
-can ingest TuneIn data without bespoke glue code.
+`TuneInStation.to_release()` returns a canonical `mediavocab.Release`. This
+lets downstream consumers, such as OCP, recommendation engines, and catalogue
+importers, ingest TuneIn data without custom glue code.
 
-Per mediavocab axiom 8 (station identity), each TuneIn channel is
-modelled as a `Work` with `MediaType.RADIO`, and the playable stream
-URL is a `Release` with `StreamMode.CONTINUOUS` (live linear
-broadcast — not seekable on-demand audio).
+Under mediavocab axiom 8 (station identity), each TuneIn channel is a `Work`
+with `MediaType.RADIO`. The playable stream URL is a `Release` with
+`StreamMode.CONTINUOUS`, since it is a live linear broadcast rather than
+seekable on-demand audio.
 
 ```python
 from tunein import TuneIn
 
-# Fast path — search payload only.
+# Fast path: search payload only.
 for release in (s.to_release() for s in TuneIn.search("BBC Radio 4")):
     print(release.uri, release.codec, release.bitrate)
 
-# Rich path — opt in to the per-station Describe.ashx call to populate
-# genre, language, country, call-sign, slogan, etc.
+# Rich path: opt in to the per-station Describe.ashx call to get
+# genre, language, country, call sign, slogan, and more.
 for station in TuneIn.search("BBC Radio 4", enrich=True):
     release = station.to_release()
     print(release.work.title)            # "BBC Radio 4"
     print(release.work.country)          # "GB"  (parsed from "London, UK")
     print(release.work.language)         # "en"  (mapped from "English")
     print(release.work.content_genres)   # ["news"]  (mapped to GENRE_NEWS)
-    print(release.work.aka)              # ["BBC R4"]   (call-sign)
+    print(release.work.aka)              # ["BBC R4"]   (call sign)
     print(release.codec, release.bitrate)  # "aac", "128"
     print(release.audio_channels)        # "stereo"
 ```
 
-TuneIn's `Tune.ashx` endpoint returns multiple stream URLs per station
-(different bitrates, mirrors, and protocols — HLS, MP3, AAC). Each
-stream becomes its own `Release` so consumers can pick the best fit at
-playback time.
+TuneIn's `Tune.ashx` endpoint returns several stream URLs per station, at
+different bitrates, mirrors, and protocols (HLS, MP3, AAC). Each stream
+becomes its own `Release`, so a consumer can pick the best fit at playback
+time.
 
-The full set of mediavocab external ids emitted is:
+TuneIn emits these mediavocab external ids:
 
 | key                  | source                                    |
 | -------------------- | ----------------------------------------- |
@@ -73,33 +80,31 @@ The full set of mediavocab external ids emitted is:
 
 Enriched stations also carry `slogan`, `location`, `frequency`, `band`,
 `twitter_id`, and `content_classification` under `work.extra`. The
-now-playing label (when present) is preserved in
-`work.extra["current_track"]`.
+now-playing label, when present, stays in `work.extra["current_track"]`.
 
-#### Why no `Programme` / `Schedule`?
+#### Why no `Programme` or `Schedule`?
 
-mediavocab 0.3 introduced `Programme` and `Schedule` for EPG data. The
-TuneIn search/browse endpoints expose a *now-playing* label but no
-start/end timestamps, and `Programme` requires an ISO-validated
-`starts_at`. This client therefore preserves the now-playing string in
-`work.extra["current_track"]` rather than fabricating a timestamp. If a
-future TuneIn endpoint exposes a real schedule feed, it can be lifted
-into `Programme(work=show_ref, channel=station_ref, starts_at=...)`
-without changing the existing surface.
+mediavocab 0.3 added `Programme` and `Schedule` for EPG data. The TuneIn
+search and browse endpoints expose a now-playing label but no start or end
+timestamps, and `Programme` requires an ISO-validated `starts_at`. TuneIn
+keeps the now-playing string in `work.extra["current_track"]` instead of
+fabricating a timestamp. If a future TuneIn endpoint exposes a real schedule
+feed, that data can move into `Programme(work=show_ref, channel=station_ref,
+starts_at=...)` without changing the existing interface.
 
 ## Pluggable HTTP transport
 
-By default the client uses :mod:`requests`. For stealthier scraping
-(TLS fingerprint matching a real browser via
-[curl_cffi](https://github.com/lexiforest/curl_cffi)), install the
-`stealth` extra and set the `TUNEIN_TRANSPORT` env var:
+By default the client uses `requests`. For scraping that is harder to
+block, install the `stealth` extra, which matches the TLS fingerprint of a
+real browser via [curl_cffi](https://github.com/lexiforest/curl_cffi), and
+set the `TUNEIN_TRANSPORT` environment variable:
 
 ```bash
 pip install tunein[stealth]
 export TUNEIN_TRANSPORT=curl_cffi
 ```
 
-You can also inject any session-shaped object explicitly:
+You can also pass in any session-shaped object directly:
 
 ```python
 from tunein import TuneIn
@@ -111,6 +116,14 @@ client = TuneIn(session=s)
 results = client.search_stations("BBC Radio 4")
 ```
 
-`TuneIn.search`, `TuneIn.featured`, and `TuneIn.get_stream_urls` also
-accept a `session=` keyword for one-shot calls without instantiating
-the client.
+`TuneIn.search`, `TuneIn.featured`, and `TuneIn.get_stream_urls` also accept
+a `session=` keyword for one-shot calls that skip creating a client.
+
+## Related projects
+
+- [mediavocab](https://github.com/JarbasAl/mediavocab) — the shared media
+  vocabulary this client emits data into.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Rewrites the README's prose in Simplified Technical English for clarity: shorter sentences, active voice, no marketing language. Adds a short Install section and a License section, and keeps every existing fact, code example, and table unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized installation and usage guidance, including updated CLI examples and help instructions.
  * Expanded documentation for mediavocab integration, station identity, and current-track handling.
  * Clarified HTTP transport options, including stealth transport configuration and custom sessions.
  * Added related projects and Apache-2.0 license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->