### PR TITLE
docs: QA pass — accuracy, org-move URLs, related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TuneIn
 
 TuneIn is an unofficial Python client for the TuneIn radio API. It integrates
-with [mediavocab](https://github.com/JarbasAl/mediavocab) so callers get
+with [mediavocab](https://github.com/TigreGotico/mediavocab) so callers get
 typed, canonical media objects instead of raw API responses.
 
 ## Install
@@ -121,8 +121,11 @@ a `session=` keyword for one-shot calls that skip creating a client.
 
 ## Related projects
 
-- [mediavocab](https://github.com/JarbasAl/mediavocab) — the shared media
+- [mediavocab](https://github.com/TigreGotico/mediavocab) — the shared media
   vocabulary this client emits data into.
+- [audiobooker](https://github.com/LeMetadatarr/audiobooker) — sibling
+  LeMetadatarr client that emits mediavocab `Release` objects for
+  public-domain audiobooks.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.9"
 keywords = ["TuneIn", "internet radio"]
 
 [project.urls]
-Homepage = "https://github.com/OpenJarbas/tunein"
+Homepage = "https://github.com/LeMetadatarr/tunein"
 
 [project.scripts]
 tunein = "tunein.cli:main"


### PR DESCRIPTION
## What was wrong

- README linked to `https://github.com/JarbasAl/mediavocab`, which returns 404. The repo actually lives at `https://github.com/TigreGotico/mediavocab`. Fixed both occurrences.
- `pyproject.toml` `[project.urls]` Homepage still pointed at the pre-move `OpenJarbas/tunein` URL. Updated to `https://github.com/LeMetadatarr/tunein`.
- Related projects section only listed the mediavocab dependency; added `audiobooker` (LeMetadatarr), a sibling client that also emits mediavocab `Release` objects.

Everything else in the README (install command, CLI usage, Python API, `to_release()` behavior, external-id table, transport/stealth section) was checked against the current source in `tunein/__init__.py`, `tunein/cli.py`, and `tunein/transport.py` and matches.

## Model usage

Claude (sonnet) authored these changes.