### PR TITLE
fix: pin mediavocab>=2.0.0a0 (2.x prerelease has the API tunein targets)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "TuneIn radio api"
 dependencies = [
     "requests",
-    "mediavocab>=1.0.0",
+    "mediavocab>=2.0.0a0",
 ]
 license = {text = "Apache-2.0"}
 authors = [{name = "JarbasAI", email = "jarbasai@mailfence.com"}]


### PR DESCRIPTION
Published mediavocab stable is 1.1.0 with the old API; tunein targets the 2.x prerelease API (currently 2.0.0a2). `mediavocab>=1.0.0` let pip resolve the incompatible 1.1.0 stable in a fresh venv.

Fix: prerelease floor pin `mediavocab>=2.0.0a0`. Verified locally against mediavocab 2.0.0a2: 92/92 tests pass.