### PR TITLE
ci: grant conventional-label workflow write permissions

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [ opened, edited ]
 name: conventional-release-labels
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds write permissions to pull-requests and issues to fix labeling.